### PR TITLE
[activerecord] 

### DIFF
--- a/kam/app/models/active_record_schema.py
+++ b/kam/app/models/active_record_schema.py
@@ -13,10 +13,12 @@ class ActiveRecordSchema():
         # call definition function
         definition_function(ar_schema)
 
-    def create_table(self, table_name, columns):
+    def create_table(self, table_name, columns, constraints):
         """
         called by the schema when loaded
         """
 
         # fill db schema
-        self.db_schema[table_name] = columns
+        self.db_schema[table_name] = dict(
+            columns=columns,
+            constraints=constraints)

--- a/kam/app/models/sql_database.py
+++ b/kam/app/models/sql_database.py
@@ -241,14 +241,13 @@ class SqlDatabase(BaseDatabase):
         for table, column, foreign_table, foreign_column in schema_constraints:
 
             # retrieve table content
-            table_content = table_constraints.get(table, [])
+            table_content = table_constraints.get(table, {})
             table_constraints[table] = table_content
 
             # fill table content
-            table_content.append(dict(
-                column=column,
+            table_content[column] = dict(
                 foreign_table=foreign_table,
-                foreign_column=foreign_column))
+                foreign_column=foreign_column)
 
         return table_constraints
 

--- a/kam/app/models/sql_database.py
+++ b/kam/app/models/sql_database.py
@@ -620,7 +620,8 @@ class SqlDatabase(BaseDatabase):
             # fill value
             if column_data_type == "string":
                 column_values.append("%s")
-                query_params.append(f"'{value}'")
+                # query_params.append(f"'{value}'")
+                query_params.append(value)
             elif column_data_type == "integer":
                 column_values.append("%s")
                 query_params.append(value)
@@ -667,7 +668,8 @@ class SqlDatabase(BaseDatabase):
             # fill value
             if column_data_type == "string":
                 update_rows.append(f"\n\"{column}\" = %s")
-                query_params.append(f"'{value}'")
+                # query_params.append(f"'{value}'")
+                query_params.append(value)
             elif column_data_type == "integer":
                 update_rows.append(f"\n\"{column}\" = %s")
                 query_params.append(value)

--- a/kam/templates/model.py
+++ b/kam/templates/model.py
@@ -7,10 +7,7 @@ class {{model_klass_name}}(ActiveRecord):
     def __init__(self, **kwargs):
 
         # retrieve {{model_klass_name.lower()}} attributes
-        self.id = kwargs.get("id"){% for instance_variable, data_type in instance_variable_types.items() if data_type != "references" %}
-        self.{{instance_variable}} = kwargs.get("{{instance_variable}}"){% endfor %}
-        self.created_at = kwargs.get("created_at")
-        self.updated_at = kwargs.get("updated_at")
+        super().__init__(**kwargs)
 
     def __repr__(self):
 

--- a/kam/templates/schema.py
+++ b/kam/templates/schema.py
@@ -2,13 +2,15 @@
 from kam.app.models.active_record_schema import ActiveRecordSchema
 
 
-def define(self):{% for table_name, table_columns in table_columns.items() %}
+def define(self):{% for table_name, columns in table_columns.items() %}
 
     self.create_table(
         "{{table_name}}",
-        dict({% for column in table_columns %}
+        dict({% for column in columns %}
             {{column["column"]}}="{{column["data_type"]}}",{% endfor %}
-            timestamps=True)){% endfor %}
+            timestamps=True),
+        dict({% for constraint in table_constraints.get(table_name, []) %}
+            {{constraint["column"]}}="{{constraint["foreign_table"]}}",{% endfor %})){% endfor %}
 
 
 ActiveRecordSchema.define(define)

--- a/kam/templates/schema.py
+++ b/kam/templates/schema.py
@@ -9,8 +9,8 @@ def define(self):{% for table_name, columns in table_columns.items() %}
         dict({% for column in columns %}
             {{column["column"]}}="{{column["data_type"]}}",{% endfor %}
             timestamps=True),
-        dict({% for constraint in table_constraints.get(table_name, []) %}
-            {{constraint["column"]}}="{{constraint["foreign_table"]}}",{% endfor %})){% endfor %}
+        dict({% for constraint, content in table_constraints.get(table_name, {}).items() %}
+            {{constraint}}="{{content["foreign_table"]}}",{% endfor %})){% endfor %}
 
 
 ActiveRecordSchema.define(define)


### PR DESCRIPTION

move instance variable initialisation from generated models to base class

change the implementation for `belongs_to` and `has_many` from `__getattr__` to dedicated injected functions

add foreign keys to `schema.py`
